### PR TITLE
fix: s3 bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ No modules.
 | [aws_lambda_event_source_mapping.lacework-alerts-sqs-to-lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.lacework_sqs_to_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_s3_bucket.lacework_alerts_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.alerts_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_acl.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_sqs_queue.lacework_alerts_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.lacework_alerts_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |

--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,14 @@ resource "aws_s3_bucket" "lacework_alerts_bucket" {
   bucket = var.aws_s3_bucket_name
 }
 
+resource "aws_s3_bucket_ownership_controls" "alerts_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.lacework_alerts_bucket.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "example" {
   bucket = aws_s3_bucket.lacework_alerts_bucket.id
   acl    = "private"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
To enable bucket ACL the ObjectOwnership parameter must be set to ObjectWriter.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
ran terraform plan
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/GROW-1534
<!--
  Include the link to a Jira/Github issue
-->