### PR TITLE
fix: S3 bucket ACL dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ No modules.
 | [aws_lambda_event_source_mapping.lacework-alerts-sqs-to-lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_function.lacework_sqs_to_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_s3_bucket.lacework_alerts_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_public_access_block.alerts_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_ownership_controls.alerts_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_acl.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_sqs_queue.lacework_alerts_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |

--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,14 @@ resource "aws_s3_bucket" "lacework_alerts_bucket" {
   bucket = var.aws_s3_bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "alerts_bucket_access" {
+  bucket                  = aws_s3_bucket.lacework_alerts_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_ownership_controls" "alerts_bucket_ownership_controls" {
   bucket = aws_s3_bucket.lacework_alerts_bucket.id
 
@@ -163,6 +171,10 @@ resource "aws_s3_bucket_ownership_controls" "alerts_bucket_ownership_controls" {
 resource "aws_s3_bucket_acl" "example" {
   bucket = aws_s3_bucket.lacework_alerts_bucket.id
   acl    = "private"
+  depends_on = [
+    aws_s3_bucket_public_access_block.alerts_bucket_access,
+    aws_s3_bucket_ownership_controls.alerts_bucket_ownership_controls
+  ]
 }
 
 # AWS SQS


### PR DESCRIPTION
## Summary

It is possible for the S3 bucket ACL resource to be created before the ownership controls, leading a failure to apply the ACL.  We need to define an explicit dependency.

Added a public access block.

## How did you test this change?

As can be seen from https://g.codefresh.io/build/6480402325053f6cc74dc5fa there is no change in TF plan.  This code change only sets the order in which resources are created.

## Issue

https://lacework.atlassian.net/browse/GROW-1835